### PR TITLE
CI: replace v4 with sha of v4

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build wads
       run: python build.py --compile-wads
     - name: Upload texture-wads-artifact
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: texture-wads-artifact
         path: texture-wads/*.wad
@@ -48,7 +48,7 @@ jobs:
     - name: Build progs
       run: python build.py --compile-progs
     - name: Upload progs-artifact
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: progs-artifact
         path: lq1/*progs.dat
@@ -64,7 +64,7 @@ jobs:
     - name: Install dependencies
       run: bash -x .github/scripts/install_deps.sh
     - name: Download texture-wads-artifact
-      uses: actions/download-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         name: texture-wads-artifact
         path: texture-wads
@@ -73,7 +73,7 @@ jobs:
         cd lq1/maps
         python compile_maps.py -d src/${{ matrix.map_dir }}
     - name: Upload maps-artifact
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: maps-artifact-${{ matrix.map_dir }}
         if-no-files-found: error
@@ -88,17 +88,17 @@ jobs:
     - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2
     # Download all the artifacts created so far
     - name: Download texture-wads-artifact
-      uses: actions/download-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         name: texture-wads-artifact
         path: texture-wads
     - name: Download progs-artifact
-      uses: actions/download-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         name: progs-artifact
         path: lq1/
     - name: Download maps-artifacts
-      uses: actions/download-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
       with:
         pattern: maps-artifact-*
         path: lq1/maps/
@@ -120,32 +120,32 @@ jobs:
         cd ..
     # Upload the completed release artifacts
     - name: Upload full.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: full.zip
         path: releases/full.zip
     - name: Upload mod.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: mod.zip
         path: releases/mod.zip
     - name: Upload lite.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: lite.zip
         path: releases/lite.zip
     - name: Upload mod_lite.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: mod_lite.zip
         path: releases/mod_lite.zip
     - name: Upload server.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: server.zip
         path: releases/server.zip
     - name: Upload dev.zip
-      uses: actions/upload-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: dev.zip
         path: releases/dev.zip
@@ -159,7 +159,7 @@ jobs:
         release_type: [full, mod, lite, mod_lite, server, dev]
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@1e31de5234b9f8995739874a8ce0492dc87873e2
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: ${{ matrix.release_type }}.zip
           path: releases/


### PR DESCRIPTION

<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->
replace v4 with sha of v4 to prevent pin exploits

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->
![image](https://github.com/user-attachments/assets/339b6be1-2a72-4a51-899c-9ae2e19af465)

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
