### PR TITLE
GH: Added CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,18 @@
 
 # ZungryWare
 lq1/maps/**/lqdm*	@ZungrySoft
-lq1/maps/**/e1m2*	@ZungrySoft
-lq1/maps/**/e1m3*	@ZungrySoft
-lq1/maps/**/e1m4*	@ZungrySoft
-lq1/maps/**/e1m5*	@ZungrySoft
+lq1/maps/**/e1*		@ZungrySoft
+lq1/maps/**/e2m2*	@ZungrySoft
 lq1/maps/**/e4m1*	@ZungrySoft
+
+# Nolcoz
+lq1/maps/**/e1m7*	@Nolcoz
+lq1/maps/**/e2m3*	@Nolcoz
+lq1/maps/**/e2m4*	@Nolcoz
+lq1/maps/**/e2m5*	@Nolcoz
+lq1/maps/**/e3m3*	@Nolcoz
+lq1/maps/**/e3m4*	@Nolcoz
+lq1/maps/**/e3m6*	@Nolcoz
+lq1/maps/**/e4m3*	@Nolcoz
+lq1/maps/**/e4m4*	@Nolcoz
+lq1/maps/**/e4m5*	@Nolcoz


### PR DESCRIPTION
### Description of Changes
---
A CODEOWNERS file allows you to set up specific files as being 'owned' by particular users. What this means is that any time a PR is opened that modifies that file, its owner will automatically be added as a reviewer. (It is also possible to set it up so that the PR cannot be merged without that user's approval, but that is optional and beyond the scope of this change.) I think this is useful so that contributors who are particular about their submissions are automatically kept in the loop if someone else is tinkering with their work.

I've started this file off with just stuff I want to be owner of. If anyone else wants me to add stuff here for them to be owner of, I can add it before this PR gets merged. Otherwise, it can be added later with a separate PR.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
