### PR TITLE
CI: Stop dependabot trying to label PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    labels:
-      - "infra"
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
### Description of Changes
---
As we're not using labels there aren't any configured and so dependabot PRs always have a commit noting the missing label. This'll stop that.

### Visual Sample
---
(n/a)

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
