### PR TITLE
BUILD: removed the trailing space from "death1.wav "

### DIFF
--- a/build_components.json
+++ b/build_components.json
@@ -208,7 +208,7 @@
             "sound/plats/train2.wav",
             "sound/player/axhit1.wav",
             "sound/player/axhit2.wav",
-            "sound/player/death1.wav ",
+            "sound/player/death1.wav",
             "sound/player/death2.wav",
             "sound/player/death3.wav",
             "sound/player/death4.wav",


### PR DESCRIPTION

<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->
fixes this

[RandomBrushes](https://github.com/RandomBrushes) (https://github.com/lavenderdotpet/LibreQuake/pull/342#discussion_r2483753521)
`
Due to a trailing space in build_components.json, this file is included into pak0.pak as death1.wav_. This is not a problem with this pull request itself, but perhaps can be easily fixed as part of it? (not sure if a one-line-fix needs its own pull request)
`
### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->
<img width="191" height="40" alt="image" src="https://github.com/user-attachments/assets/4e9cd917-bbd0-4347-9f13-83d97e888fab" />

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
