### PR TITLE
[GH] Add v0.09-beta release to appstream metadata

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
@@ -70,6 +70,32 @@
     <content_attribute id="social-chat">intense</content_attribute>
   </content_rating>
   <releases>
-    <release version="v0.08-beta" date="2024-11-09" />
+    <release version="v0.09-beta" date="2025-11-05">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.09-beta</url>
+    </release>
+    <release version="v0.08-beta" date="2024-11-09">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.08-beta</url>
+    </release>
+    <release version="v0.07-beta" date="2024-08-16">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.07-beta</url>
+    </release>
+    <release version="v0.06-beta" date="2024-02-03">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.06-beta</url>
+    </release>
+    <release version="v0.05-beta" date="2023-12-21">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.05-beta</url>
+    </release>
+    <release version="v0.04-beta" date="2023-12-13">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.04-beta</url>
+    </release>
+    <release version="v0.03-beta" date="2023-12-08">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.03-beta</url>
+    </release>
+    <release version="v0.02-beta" date="2022-01-08">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.02-beta</url>
+    </release>
+    <release version="v0.01-beta" date="2022-01-07">
+      <url type="details">https://github.com/lavenderdotpet/LibreQuake/releases/tag/v0.01-beta</url>
+    </release>
   </releases>
 </component>


### PR DESCRIPTION
### Description of Changes
---
v0.09-beta was missed from the Appstream metainfo.xml with the version bump. Without this, Flathub's versioning won't track the new release properly.

I've also added links to release notes and older versions for historic information.

### Visual Sample
---
n/a

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
