### PR TITLE
[GH] Remove vkquake from desktop file

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
@@ -16,7 +16,7 @@ Exec=io.github.lavenderdotpet.LibreQuake.open-userdir.sh
 
 [Desktop Action ironwail]
 Name=Ironwail
-Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Icon=io.github.lavenderdotpet.LibreQuake.ironwail
 Exec=io.github.lavenderdotpet.LibreQuake.sh ironwail
 
 [Desktop Action quakespasm]
@@ -26,20 +26,10 @@ Exec=io.github.lavenderdotpet.LibreQuake.sh quakespasm
 
 [Desktop Action qssm]
 Name=QSS-M
-Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Icon=io.github.lavenderdotpet.LibreQuake.qss-m
 Exec=io.github.lavenderdotpet.LibreQuake.sh qssm
 
 # [Desktop Action vkquake]
 # Name=VkQuake
-# Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+# Icon=io.github.lavenderdotpet.LibreQuake.vkquake
 # Exec=io.github.lavenderdotpet.LibreQuake.sh vkquake
-#
-# [Desktop Action fteqw]
-# Name=FTEQW
-# Icon=io.github.lavenderdotpet.LibreQuake.fteqw
-# Exec=io.github.lavenderdotpet.LibreQuake.sh fteqw
-#
-# [Desktop Action tyrquake]
-# Name=TyrQuake
-# Icon=io.github.lavenderdotpet.LibreQuake.tyrquake
-# Exec=io.github.lavenderdotpet.LibreQuake.sh tyrquake


### PR DESCRIPTION
### Description of Changes
---
As we're pulling vkQuake from the Flatpak for now it should also be removed from the .desktop file.

### Visual Sample
---
Before:
<img width="315" height="342" alt="image" src="https://github.com/user-attachments/assets/29488222-cfe3-457c-8b83-84ce7ed4a201" />

After:
<img width="643" height="212" alt="image" src="https://github.com/user-attachments/assets/28882606-44ba-416d-bf70-12458fac4908" />

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
