### PR TITLE
META: Add vcs-browser url to metainfo

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
@@ -42,7 +42,7 @@
   <url type="homepage">https://librequake.queer.sh/</url>
   <url type="vcs-browser">https://github.com/lavenderdotpet/LibreQuake</url>
   <url type="bugtracker">https://github.com/lavenderdotpet/LibreQuake/issues</url>
-  <url type="contribute">https://github.com/lavenderdotpet/LibreQuake</url>
+  <url type="contribute">https://github.com/lavenderdotpet/LibreQuake/issues/223</url>
   <screenshots>
     <screenshot type="default">
       <caption>LibreQuake</caption>

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
@@ -40,6 +40,7 @@
     <color type="primary" scheme_preference="dark">#241f31</color>
   </branding>
   <url type="homepage">https://librequake.queer.sh/</url>
+  <url type="vcs-browser">https://github.com/lavenderdotpet/LibreQuake</url>
   <url type="bugtracker">https://github.com/lavenderdotpet/LibreQuake/issues</url>
   <url type="contribute">https://github.com/lavenderdotpet/LibreQuake</url>
   <screenshots>


### PR DESCRIPTION
### Description of Changes
---
This is now a linter complaint when building Flatpak distributions, and a "strongly recommended" part of the `metainfo.xml`. See https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/20 for the linter complaint popping up.

The effect of this is that a new link will appear on Flathub (and graphical package managers) for the source code repository (cf. the visual sample below taken from the Exult Flatpak)

### Visual Sample
---
<img width="1658" height="489" alt="image" src="https://github.com/user-attachments/assets/487c437c-3c32-46cb-a6fd-e31ff010c613" />


### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
