### PR TITLE
META: Update metainfo for Flatpak engine changes

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
@@ -30,8 +30,9 @@
       the GPL-2.0 license:</p>
     <ul>
       <li>Ironwail, a port focused on improving performance for highly complex maps and mods</li>
-      <li>QuakeSpasm, a basic modern port of the Quake engine and the basis of the others</li>
-      <li>QSS-M, to provide OpenGL 1.2/2.x support for older hardware</li>
+      <li>FTEQW, with support for multiple games based on the Quake engine and good multiplayer support</li>
+      <li>QrustyQuake, aimed at faithfulness to the original Windows version of the engine while modernizing
+        the code and safely extending some engine limitations.</li>
     </ul>
     <p>Please see the LibreQuake Github page for details about used licenses.</p>
   </description>
@@ -71,6 +72,7 @@
   </screenshots>
   <categories>
     <category>Game</category>
+    <category>Shooter</category>
   </categories>
   <keywords>
     <keyword>shooter</keyword>
@@ -78,13 +80,15 @@
     <keyword>quake</keyword>
   </keywords>
   <provides>
-    <id>librequake.desktop</id>
-    <binary>quakespasm</binary>
+    <id>io.github.andrei-drexler.ironwail</id>
+    <id>io.github.cyanbun96.qrustyquake</id>
     <binary>ironwail</binary>
-    <binary>qss-m</binary>
+    <binary>fteqw</binary>
+    <binary>qrustyquake</binary>
   </provides>
   <supports>
     <control>gamepad</control>
+    <internet>offline-only</internet>
   </supports>
   <recommends>
     <control>keyboard</control>


### PR DESCRIPTION
### Description of Changes
Updated the metainfo with upcoming engine changes for the Flatpak:

- [Remove AI-coded engines](https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/27)
- [Add QrustyQuake](https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/28)
- [Add fteqw](https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/29)

Also added the `Shooter` category and an optional `supports` tag to denote the LQ flatpak will work offline, and added rDNS IDs for Ironwail and QrustyQuake under `provides` as per [FreeDesktop docs](https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-provides).

I've left fteqw's ID out of the `provides` tags as the spec says

> Contains the component-ID of another software component. The presence of this tag indicates that the software component containing it is able to provide all functionality of the one referenced in the `<provides/>` ↪ `<id/>` tag.

As we do not build the entirety of fteqw's functionality, the metadata should probably not signal that it can provide it. Ironwail and QrustyQuake meanwhile have no additional functionality beyond running Quake-based content so I'm happy with adding this.


### Visual Sample
[none]

### Checklist
- [X] I have read the LibreQuake contribution guidelines
- [X] I have thoroughly tested my changes to the best of my ability
- [X] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
